### PR TITLE
Fix the tpm2-policy dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ biscuit = "0.5.0"
 serde_json = "1.0"
 base64 = "0.12.1"
 atty = "0.2.14"
-tpm2-policy = { version = "0.4.0", path = "../rust-tpm2-policy" }
+tpm2-policy = "0.4.0"


### PR DESCRIPTION
The tpm2-policy 0.4.0 release has been published so no need to
rely on a local checkout.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>