### PR TITLE
bump rust-rss-eapi to 6.1.1, tpm2-policy to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ license = "EUPL-1.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tss-esapi = "5.0"
+tss-esapi = "6.1.1"
 serde = "1.0"
 biscuit = "0.5.0"
 serde_json = "1.0"
 base64 = "0.12.1"
 atty = "0.2.14"
-tpm2-policy = "0.4.0"
+tpm2-policy = "0.5.0"


### PR DESCRIPTION
we want to bump to 7.alpha.1 tag but that doesn't contain https://github.com/parallaxsecond/rust-tss-esapi/pull/261 so bumping to a latest main version until that fix is tagged in the next alpha release

I've also bumped rust-tpm2-policy here: https://github.com/fedora-iot/rust-tpm2-policy/pull/1

Signed-off-by: Antonio Murdaca <runcom@linux.com>