### PR TITLE
feat: switch to josekit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: Continuous Integration
+on: [push, pull_request]
+jobs:
+  formatting:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  tests:
+    name: Perform tests
+    runs-on: ubuntu-latest
+    container: fedora:latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+            dnf install -y \
+                tpm2-tss-devel \
+                swtpm swtpm-tools \
+                rust cargo clippy
+      - name: Start swtpm
+        run: |
+            mkdir /tmp/tpmdir
+            swtpm_setup --tpm2 \
+                --tpmstate /tmp/tpmdir \
+                --createek --decryption --create-ek-cert \
+                --create-platform-cert \
+                --display
+            swtpm socket --tpm2 \
+                --tpmstate dir=/tmp/tpmdir \
+                --flags startup-clear \
+                --ctrl type=tcp,port=2322 \
+                --server type=tcp,port=2321 \
+                --daemon
+      - name: Run PCR tests
+        run: |
+            TCTI=swtpm: ./tests/test_pcr
+      - name: Run policy tests
+        run: |
+            TCTI=swtpm: ./tests/test_policy
+      - name: Run clippy
+        run: cargo clippy -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,11 @@ license = "EUPL-1.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1"
 tss-esapi = "6.1.1"
 serde = "1.0"
-biscuit = "0.5.0"
+josekit = "0.7.4"
 serde_json = "1.0"
 base64 = "0.12.1"
 atty = "0.2.14"
-tpm2-policy = "0.5.1"
+tpm2-policy = "0.5.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,18 +13,14 @@
 // limitations under the License.
 
 use std::convert::{TryFrom, TryInto};
-use std::error::Error;
-use std::fmt;
-
 use std::env;
 use std::io::{self, Read, Write};
 
-use biscuit::jwe;
-use biscuit::CompactJson;
-
+use anyhow::{bail, Context, Error, Result};
+use josekit::jwe::{alg::direct::DirectJweAlgorithm::Dir, enc::A256GCM};
 use serde::{Deserialize, Serialize};
-
 use tpm2_policy::TPMPolicyStep;
+use tss_esapi::structures::SensitiveData;
 
 mod cli;
 mod tpm_objects;
@@ -32,116 +28,7 @@ mod utils;
 
 use cli::TPM2Config;
 
-use tss_esapi::structures::SensitiveData;
-
-#[derive(Debug)]
-enum PinError {
-    Text(&'static str),
-    NoCommand,
-    Serde(serde_json::Error),
-    IO(std::io::Error),
-    TPM(tss_esapi::Error),
-    JWE(biscuit::errors::Error),
-    Base64Decoding(base64::DecodeError),
-    Utf8(std::str::Utf8Error),
-    FromUtf8(std::string::FromUtf8Error),
-    PolicyError(tpm2_policy::Error),
-}
-
-impl PinError {}
-
-impl fmt::Display for PinError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            PinError::Text(e) => write!(f, "Error: {}", e),
-            PinError::Serde(err) => {
-                write!(f, "Serde error: ")?;
-                err.fmt(f)
-            }
-            PinError::IO(err) => {
-                write!(f, "IO error: ")?;
-                err.fmt(f)
-            }
-            PinError::TPM(err) => {
-                write!(f, "TPM error: ")?;
-                err.fmt(f)
-            }
-            PinError::JWE(err) => {
-                write!(f, "JWE error: ")?;
-                err.fmt(f)
-            }
-            PinError::Base64Decoding(err) => {
-                write!(f, "Base64 Decoding error: ")?;
-                err.fmt(f)
-            }
-            PinError::Utf8(err) => {
-                write!(f, "UTF8 error: ")?;
-                err.fmt(f)
-            }
-            PinError::FromUtf8(err) => {
-                write!(f, "UTF8 error: ")?;
-                err.fmt(f)
-            }
-            PinError::NoCommand => write!(f, "No command provided"),
-            PinError::PolicyError(err) => {
-                write!(f, "Policy Error: ")?;
-                err.fmt(f)
-            }
-        }
-    }
-}
-
-impl Error for PinError {}
-
-impl From<std::io::Error> for PinError {
-    fn from(err: std::io::Error) -> Self {
-        PinError::IO(err)
-    }
-}
-
-impl From<tpm2_policy::Error> for PinError {
-    fn from(err: tpm2_policy::Error) -> Self {
-        PinError::PolicyError(err)
-    }
-}
-
-impl From<&'static str> for PinError {
-    fn from(err: &'static str) -> Self {
-        PinError::Text(err)
-    }
-}
-
-impl From<serde_json::Error> for PinError {
-    fn from(err: serde_json::Error) -> Self {
-        PinError::Serde(err)
-    }
-}
-
-impl From<tss_esapi::Error> for PinError {
-    fn from(err: tss_esapi::Error) -> Self {
-        PinError::TPM(err)
-    }
-}
-
-impl From<biscuit::errors::Error> for PinError {
-    fn from(err: biscuit::errors::Error) -> Self {
-        PinError::JWE(err)
-    }
-}
-
-impl From<base64::DecodeError> for PinError {
-    fn from(err: base64::DecodeError) -> Self {
-        PinError::Base64Decoding(err)
-    }
-}
-
-impl From<std::str::Utf8Error> for PinError {
-    fn from(err: std::str::Utf8Error) -> Self {
-        PinError::Utf8(err)
-    }
-}
-
-fn perform_encrypt(cfg: TPM2Config, input: Vec<u8>) -> Result<(), PinError> {
+fn perform_encrypt(cfg: TPM2Config, input: Vec<u8>) -> Result<()> {
     let key_type = match &cfg.key {
         None => "ecc",
         Some(key_type) => key_type,
@@ -161,17 +48,9 @@ fn perform_encrypt(cfg: TPM2Config, input: Vec<u8>) -> Result<(), PinError> {
 
     let (_, policy_digest) = policy_runner.send_policy(&mut ctx, true)?;
 
-    let key_bytes = ctx.get_random(32)?;
-    let key_bytes: &[u8] = key_bytes.value();
-    let mut jwk = biscuit::jwk::JWK::new_octet_key(&key_bytes, biscuit::Empty {});
-    jwk.common.algorithm = Some(biscuit::jwa::Algorithm::ContentEncryption(
-        biscuit::jwa::ContentEncryptionAlgorithm::A256GCM,
-    ));
-    jwk.common.key_operations = Some(vec![
-        biscuit::jwk::KeyOperations::Encrypt,
-        biscuit::jwk::KeyOperations::Decrypt,
-    ]);
-    let jwk_str = serde_json::to_string(&jwk)?;
+    let mut jwk = josekit::jwk::Jwk::generate_oct_key(32).context("Error generating random JWK")?;
+    jwk.set_key_operations(vec!["encrypt", "decrypt"]);
+    let jwk_str = serde_json::to_string(&jwk.as_ref())?;
 
     let public = tpm_objects::create_tpm2b_public_sealed_object(policy_digest)?;
     let jwk_str = SensitiveData::try_from(jwk_str.as_bytes().to_vec())?;
@@ -183,52 +62,37 @@ fn perform_encrypt(cfg: TPM2Config, input: Vec<u8>) -> Result<(), PinError> {
 
     let jwk_pub = tpm_objects::get_tpm2b_public(jwk_result.out_public)?;
 
-    let hdr: biscuit::jwe::Header<ClevisHeader> = biscuit::jwe::Header {
-        registered: biscuit::jwe::RegisteredHeader {
-            cek_algorithm: biscuit::jwa::KeyManagementAlgorithm::DirectSymmetricKey,
-            enc_algorithm: biscuit::jwa::ContentEncryptionAlgorithm::A256GCM,
-            compression_algorithm: None,
-            media_type: None,
-            content_type: None,
-            web_key_url: None,
-            web_key: None,
-            key_id: None,
-            x509_url: None,
-            x509_chain: None,
-            x509_fingerprint: None,
-            critical: None,
-        },
-        cek_algorithm: biscuit::jwe::CekAlgorithmHeader {
-            nonce: None,
-            tag: None,
-        },
-        private: ClevisHeader {
-            clevis: ClevisInner {
-                pin: pin_type.to_string(),
-                tpm2: Tpm2Inner {
-                    hash: cfg.hash.as_ref().unwrap_or(&"sha256".to_string()).clone(),
-                    key: key_type.to_string(),
-                    jwk_pub,
-                    jwk_priv,
-                    pcr_bank: cfg.pcr_bank.clone(),
-                    pcr_ids: cfg.get_pcr_ids_str(),
-                    policy_pubkey_path: cfg.policy_pubkey_path,
-                    policy_ref: cfg.policy_ref,
-                    policy_path: cfg.policy_path,
-                },
-            },
+    let private_hdr = ClevisInner {
+        pin: pin_type.to_string(),
+        tpm2: Tpm2Inner {
+            hash: cfg.hash.as_ref().unwrap_or(&"sha256".to_string()).clone(),
+            key: key_type.to_string(),
+            jwk_pub,
+            jwk_priv,
+            pcr_bank: cfg.pcr_bank.clone(),
+            pcr_ids: cfg.get_pcr_ids_str(),
+            policy_pubkey_path: cfg.policy_pubkey_path,
+            policy_ref: cfg.policy_ref,
+            policy_path: cfg.policy_path,
         },
     };
 
-    let rand_nonce = ctx.get_random(12)?;
-    let jwe_enc_options = biscuit::jwa::EncryptionOptions::AES_GCM {
-        nonce: rand_nonce.value().to_vec(),
-    };
+    let mut hdr = josekit::jwe::JweHeader::new();
+    hdr.set_algorithm(Dir.name());
+    hdr.set_content_encryption(A256GCM.name());
+    hdr.set_claim(
+        "clevis",
+        Some(serde_json::value::to_value(private_hdr).context("Error serializing private header")?),
+    )
+    .context("Error adding clevis claim")?;
 
-    let jwe_token = biscuit::jwe::Compact::new_decrypted(hdr, input);
-    let jwe_token_compact = jwe_token.encrypt(&jwk, &jwe_enc_options)?;
-    let encoded_token = jwe_token_compact.encrypted()?.encode();
-    io::stdout().write_all(encoded_token.as_bytes())?;
+    let encrypter = Dir
+        .encrypter_from_jwk(&jwk)
+        .context("Error creating direct encrypter")?;
+    let jwe_token = josekit::jwe::serialize_compact(&input, &hdr, &encrypter)
+        .context("Error serializing JWE token")?;
+
+    io::stdout().write_all(jwe_token.as_bytes())?;
 
     Ok(())
 }
@@ -276,9 +140,9 @@ impl Tpm2Inner {
 }
 
 impl TryFrom<&Tpm2Inner> for TPMPolicyStep {
-    type Error = PinError;
+    type Error = Error;
 
-    fn try_from(cfg: &Tpm2Inner) -> Result<Self, PinError> {
+    fn try_from(cfg: &Tpm2Inner) -> Result<Self> {
         if cfg.pcr_ids.is_some() && cfg.policy_pubkey_path.is_some() {
             Ok(TPMPolicyStep::Or([
                 Box::new(TPMPolicyStep::PCRs(
@@ -322,31 +186,24 @@ struct ClevisInner {
     tpm2: Tpm2Inner,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-struct ClevisHeader {
-    clevis: ClevisInner,
-}
+fn perform_decrypt(input: Vec<u8>) -> Result<()> {
+    let input = String::from_utf8(input).context("Error reading input")?;
+    let hdr = josekit::jwt::decode_header(&input).context("Error decoding header")?;
+    let hdr_clevis = hdr.claim("clevis").context("Error getting clevis claim")?;
+    let hdr_clevis: ClevisInner =
+        serde_json::from_value(hdr_clevis.clone()).context("Error deserializing clevis header")?;
 
-impl CompactJson for Tpm2Inner {}
-impl CompactJson for ClevisHeader {}
-impl CompactJson for ClevisInner {}
-
-fn perform_decrypt(input: Vec<u8>) -> Result<(), PinError> {
-    let input = String::from_utf8(input).map_err(PinError::FromUtf8)?;
-    let token = biscuit::Compact::decode(input.trim());
-    let hdr: biscuit::jwe::Header<ClevisHeader> = token.part(0)?;
-
-    if hdr.private.clevis.pin != "tpm2" && hdr.private.clevis.pin != "tpm2plus" {
-        return Err(PinError::Text("JWE pin mismatch"));
+    if hdr_clevis.pin != "tpm2" && hdr_clevis.pin != "tpm2plus" {
+        bail!("JWE pin mismatch");
     }
 
-    let jwkpub = tpm_objects::build_tpm2b_public(&hdr.private.clevis.tpm2.jwk_pub)?;
-    let jwkpriv = tpm_objects::build_tpm2b_private(&hdr.private.clevis.tpm2.jwk_priv)?;
+    let jwkpub = tpm_objects::build_tpm2b_public(&hdr_clevis.tpm2.jwk_pub)?;
+    let jwkpriv = tpm_objects::build_tpm2b_private(&hdr_clevis.tpm2.jwk_priv)?;
 
-    let policy = TPMPolicyStep::try_from(&hdr.private.clevis.tpm2)?;
+    let policy = TPMPolicyStep::try_from(&hdr_clevis.tpm2)?;
 
-    let name_alg = crate::utils::get_hash_alg_from_name(Some(&hdr.private.clevis.tpm2.hash));
-    let key_public = tpm_objects::get_key_public(hdr.private.clevis.tpm2.key.as_str(), name_alg)?;
+    let name_alg = crate::utils::get_hash_alg_from_name(Some(&hdr_clevis.tpm2.hash));
+    let key_public = tpm_objects::get_key_public(hdr_clevis.tpm2.key.as_str(), name_alg)?;
 
     let mut ctx = utils::get_tpm2_ctx()?;
     let key_handle = utils::get_tpm2_primary_key(&mut ctx, &key_public)?;
@@ -358,20 +215,16 @@ fn perform_decrypt(input: Vec<u8>) -> Result<(), PinError> {
 
     let unsealed = ctx.execute_with_session(policy_session, |ctx| ctx.unseal(key.into()))?;
     let unsealed = &unsealed.value();
-    let unsealed = std::str::from_utf8(unsealed)?;
-    let jwk: biscuit::jwk::JWK<biscuit::Empty> = serde_json::from_str(unsealed)?;
+    let mut jwk = josekit::jwk::Jwk::from_bytes(unsealed).context("Error unmarshaling JWK")?;
+    jwk.set_algorithm(Dir.name());
+    let decrypter = Dir
+        .decrypter_from_jwk(&jwk)
+        .context("Error creating decrypter")?;
 
-    let token: biscuit::jwe::Compact<Vec<u8>, biscuit::Empty> = jwe::Compact::Encrypted(token);
+    let (payload, _) =
+        josekit::jwe::deserialize_compact(&input, &decrypter).context("Error decrypting JWE")?;
 
-    let token = token.decrypt(
-        &jwk,
-        biscuit::jwa::KeyManagementAlgorithm::DirectSymmetricKey,
-        biscuit::jwa::ContentEncryptionAlgorithm::A256GCM,
-    )?;
-    // We just decrypted the token, there should be a payload
-    let payload = token.payload()?;
-
-    io::stdout().write_all(payload)?;
+    io::stdout().write_all(&payload)?;
 
     Ok(())
 }
@@ -411,7 +264,7 @@ This command uses the following configuration properties:
     std::process::exit(2);
 }
 
-fn main() {
+fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
     let (mode, cfg) = match cli::get_mode_and_cfg(&args) {
         Err(e) => {
@@ -422,8 +275,8 @@ fn main() {
     };
 
     match mode {
-        cli::ActionMode::Summary => return print_summary(),
-        cli::ActionMode::Help => return print_help(),
+        cli::ActionMode::Summary => return Ok(print_summary()),
+        cli::ActionMode::Help => return Ok(print_help()),
         _ => {}
     };
 
@@ -433,13 +286,10 @@ fn main() {
         std::process::exit(1);
     }
 
-    if let Err(e) = match mode {
+    match mode {
         cli::ActionMode::Encrypt => perform_encrypt(cfg.unwrap(), input),
         cli::ActionMode::Decrypt => perform_decrypt(input),
-        cli::ActionMode::Summary => panic!("Summary was already handled supposedly"),
-        cli::ActionMode::Help => panic!("Help was already handled supposedly"),
-    } {
-        eprintln!("Error executing command: {}", e);
-        std::process::exit(2);
+        cli::ActionMode::Summary => unreachable!(),
+        cli::ActionMode::Help => unreachable!(),
     }
 }


### PR DESCRIPTION
This patch changes from using biscuit to josekit for JWE.
josekit uses OpenSSL for its crypto instead of ring.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>