### PR TITLE
fix: trim base64 input before attempting decryption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
       - name: Run integration tests
         run: |
             TCTI=swtpm: SKIP_CLEVIS=true cargo test -- --nocapture
+            echo "### Shell integration tests" >&2
+            TCTI=swtpm: SKIP_CLEVIS=true ./tests/integration-test.sh
       - name: Run policy tests
         run: |
             TCTI=swtpm: ./tests/test_policy

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,10 @@ struct ClevisInner {
 }
 
 fn perform_decrypt(input: Vec<u8>) -> Result<()> {
-    let input = String::from_utf8(input).context("Error reading input")?;
+    let input = String::from_utf8(input)
+        .context("Error reading input")?
+        .trim()
+        .to_string();
     let hdr = josekit::jwt::decode_header(&input).context("Error decoding header")?;
     let hdr_clevis = hdr.claim("clevis").context("Error getting clevis claim")?;
     let hdr_clevis: ClevisInner =

--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+die() {
+    echo "ERROR: ${1}" >&2
+    exit 1
+}
+
+PLAINTEXT=foobar
+jwe="$(echo "${PLAINTEXT}" | ./target/debug/clevis-pin-tpm2 encrypt {})"
+
+dec="$(echo "$jwe" | ./target/debug/clevis-pin-tpm2 decrypt)" \
+    || die "Unable to decrypt JWE passed with newline added"
+
+[ "${dec}" = "${PLAINTEXT}" ] \
+    || die "Decrypted JWE (${dec}) does not match PLAINTEXT (${PLAINTEXT})"


### PR DESCRIPTION
As the decryption input is base64-encoded, we can safely trim leading and trailing whitespace from it.

If the input has a newline, it will fail validation, e.g:

```
jwe="$(echo "foobar" | clevis-pin-tpm2 encrypt {})"
echo "${jwe}" | clevis-pin-tpm2 decrypt
Error: Error decrypting JWE

Caused by:
    0: Invalid JWE format: Invalid byte 10, offset 22.
    1: Invalid byte 10, offset 22.
```

Also include additional integration tests written in shell script.