### PR TITLE
Drop unmaintained atty dep and replace with standard library calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Patrick Uiterwijk <patrick@puiterwijk.org>"]
 edition = "2018"
 homepage = "https://github.com/fedora-iot/clevis-pin-tpm2"
 license = "MIT"
+rust-version = "1.70"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -16,5 +17,4 @@ serde = "1.0"
 josekit = "0.7.4"
 serde_json = "1.0"
 base64 = "0.22.0"
-atty = "0.2.14"
 tpm2-policy = "0.6.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use std::convert::TryFrom;
+use std::io::IsTerminal;
 
 use anyhow::{anyhow, bail, Error, Result};
 use serde::{Deserialize, Serialize};
@@ -209,7 +210,7 @@ pub(super) fn get_mode_and_cfg(args: &[String]) -> Result<(ActionMode, Option<TP
     if args.len() > 1 && args[1] == "--help" {
         return Ok((ActionMode::Help, None));
     }
-    if atty::is(atty::Stream::Stdin) {
+    if std::io::stdin().is_terminal() {
         return Ok((ActionMode::Help, None));
     }
     let (mode, cfgstr) = if args[0].contains("encrypt") && args.len() >= 2 {


### PR DESCRIPTION
The `atty` crate is officially unmaintained: https://rustsec.org/advisories/RUSTSEC-2024-0375.html - additionally, the functionality it provides (checking if a file descriptor is connected to a TTY) has been available in the Rust standard library since version 1.70.

This PR drops the `atty` dependency and switches to the `IsTerminal` implementation from the standard library.