### PR TITLE
Add JSON schema validation to reject unknown fields

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -264,7 +264,7 @@ fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
     let (mode, cfg) = match cli::get_mode_and_cfg(&args) {
         Err(e) => {
-            eprintln!("Error during parsing operation: {}", e);
+            eprintln!("Error during parsing operation: {e}");
             std::process::exit(1);
         }
         Ok((mode, cfg)) => (mode, cfg),
@@ -284,7 +284,7 @@ fn main() -> Result<()> {
 
     let mut input = Vec::new();
     if let Err(e) = io::stdin().read_to_end(&mut input) {
-        eprintln!("Error getting input token: {}", e);
+        eprintln!("Error getting input token: {e}");
         std::process::exit(1);
     }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -158,28 +158,28 @@ fn pcr_tests() {
                 eprintln!("\tStarting encrypter");
                 let encrypted = (encrypt_fn.func)(INPUT, config);
                 if let Err(e) = encrypted {
-                    eprintln!("FAILED: error: {:?}", e);
+                    eprintln!("FAILED: error: {e:?}");
                     failed += 1;
                     continue;
                 }
                 let encrypted = encrypted.unwrap();
                 eprintln!("\tStarting checker");
                 if let Err(e) = checker(&encrypted) {
-                    eprintln!("FAILED: error: {:?}", e);
+                    eprintln!("FAILED: error: {e:?}");
                     failed += 1;
                     continue;
                 }
                 eprintln!("\tStarting decrypter");
                 let decrypted = (decrypt_fn.func)(&encrypted);
                 if let Err(e) = decrypted {
-                    eprintln!("FAILED: error: {:?}", e);
+                    eprintln!("FAILED: error: {e:?}");
                     failed += 1;
                     continue;
                 }
                 let decrypted = decrypted.unwrap();
                 eprintln!("\tStarting contents checker");
                 if decrypted != INPUT {
-                    eprintln!("FAILED: '{}' (input) != '{}' (decrypted)", INPUT, decrypted);
+                    eprintln!("FAILED: '{INPUT}' (input) != '{decrypted}' (decrypted)");
                     failed += 1;
                     continue;
                 }


### PR DESCRIPTION
Adds serde(deny_unknown_fields) attribute to TPM2Config to catch
typos and invalid field names in JSON configuration. Previously,
invalid fields like "pcrs_ids" were silently ignored, which could
lead to unexpected behavior.
