### PR TITLE
bump tss-esapi to 7.7 for LLVM 22 compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.90.0"
 
 [dependencies]
 anyhow = "1"
-tss-esapi = { version = "7.5", features = ["generate-bindings"] }
+tss-esapi = { version = "7.7", features = ["generate-bindings"] }
 serde = "1.0"
 josekit = "0.7.4"
 serde_json = "1.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,15 +32,15 @@ impl TryFrom<&TPM2Config> for TPMPolicyStep {
     type Error = Error;
 
     fn try_from(cfg: &TPM2Config) -> Result<Self> {
-        if cfg.pcr_ids.is_some() && cfg.policy_pubkey_path.is_some() {
-            Ok(TPMPolicyStep::Or([
+        match (&cfg.pcr_ids, &cfg.policy_pubkey_path) {
+            (Some(_), Some(pubkey_path)) => Ok(TPMPolicyStep::Or([
                 Box::new(TPMPolicyStep::PCRs(
                     cfg.get_pcr_hash_alg(),
                     cfg.get_pcr_ids().unwrap(),
                     Box::new(TPMPolicyStep::NoStep),
                 )),
                 Box::new(get_authorized_policy_step(
-                    cfg.policy_pubkey_path.as_ref().unwrap(),
+                    pubkey_path,
                     &None,
                     &cfg.policy_ref,
                 )?),
@@ -50,21 +50,18 @@ impl TryFrom<&TPM2Config> for TPMPolicyStep {
                 Box::new(TPMPolicyStep::NoStep),
                 Box::new(TPMPolicyStep::NoStep),
                 Box::new(TPMPolicyStep::NoStep),
-            ]))
-        } else if cfg.pcr_ids.is_some() {
-            Ok(TPMPolicyStep::PCRs(
+            ])),
+            (Some(_), None) => Ok(TPMPolicyStep::PCRs(
                 cfg.get_pcr_hash_alg(),
                 cfg.get_pcr_ids().unwrap(),
                 Box::new(TPMPolicyStep::NoStep),
-            ))
-        } else if cfg.policy_pubkey_path.is_some() {
-            get_authorized_policy_step(
-                cfg.policy_pubkey_path.as_ref().unwrap(),
+            )),
+            (None, Some(pubkey_path)) => get_authorized_policy_step(
+                pubkey_path,
                 &None,
                 &cfg.policy_ref,
-            )
-        } else {
-            Ok(TPMPolicyStep::NoStep)
+            ),
+            (None, None) => Ok(TPMPolicyStep::NoStep),
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -56,11 +56,9 @@ impl TryFrom<&TPM2Config> for TPMPolicyStep {
                 cfg.get_pcr_ids().unwrap(),
                 Box::new(TPMPolicyStep::NoStep),
             )),
-            (None, Some(pubkey_path)) => get_authorized_policy_step(
-                pubkey_path,
-                &None,
-                &cfg.policy_ref,
-            ),
+            (None, Some(pubkey_path)) => {
+                get_authorized_policy_step(pubkey_path, &None, &cfg.policy_ref)
+            }
             (None, None) => Ok(TPMPolicyStep::NoStep),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,15 +134,15 @@ impl TryFrom<&Tpm2Inner> for TPMPolicyStep {
     type Error = Error;
 
     fn try_from(cfg: &Tpm2Inner) -> Result<Self> {
-        if cfg.pcr_ids.is_some() && cfg.policy_pubkey_path.is_some() {
-            Ok(TPMPolicyStep::Or([
+        match (&cfg.pcr_ids, &cfg.policy_pubkey_path) {
+            (Some(_), Some(pubkey_path)) => Ok(TPMPolicyStep::Or([
                 Box::new(TPMPolicyStep::PCRs(
                     utils::get_hash_alg_from_name(cfg.pcr_bank.as_ref()),
                     cfg.get_pcr_ids().unwrap(),
                     Box::new(TPMPolicyStep::NoStep),
                 )),
                 Box::new(utils::get_authorized_policy_step(
-                    cfg.policy_pubkey_path.as_ref().unwrap(),
+                    pubkey_path,
                     &cfg.policy_path,
                     &cfg.policy_ref,
                 )?),
@@ -152,21 +152,18 @@ impl TryFrom<&Tpm2Inner> for TPMPolicyStep {
                 Box::new(TPMPolicyStep::NoStep),
                 Box::new(TPMPolicyStep::NoStep),
                 Box::new(TPMPolicyStep::NoStep),
-            ]))
-        } else if cfg.pcr_ids.is_some() {
-            Ok(TPMPolicyStep::PCRs(
+            ])),
+            (Some(_), None) => Ok(TPMPolicyStep::PCRs(
                 utils::get_hash_alg_from_name(cfg.pcr_bank.as_ref()),
                 cfg.get_pcr_ids().unwrap(),
                 Box::new(TPMPolicyStep::NoStep),
-            ))
-        } else if cfg.policy_pubkey_path.is_some() {
-            utils::get_authorized_policy_step(
-                cfg.policy_pubkey_path.as_ref().unwrap(),
+            )),
+            (None, Some(pubkey_path)) => utils::get_authorized_policy_step(
+                pubkey_path,
                 &cfg.policy_path,
                 &cfg.policy_ref,
-            )
-        } else {
-            Ok(TPMPolicyStep::NoStep)
+            ),
+            (None, None) => Ok(TPMPolicyStep::NoStep),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,11 +158,9 @@ impl TryFrom<&Tpm2Inner> for TPMPolicyStep {
                 cfg.get_pcr_ids().unwrap(),
                 Box::new(TPMPolicyStep::NoStep),
             )),
-            (None, Some(pubkey_path)) => utils::get_authorized_policy_step(
-                pubkey_path,
-                &cfg.policy_path,
-                &cfg.policy_ref,
-            ),
+            (None, Some(pubkey_path)) => {
+                utils::get_authorized_policy_step(pubkey_path, &cfg.policy_path, &cfg.policy_ref)
+            }
             (None, None) => Ok(TPMPolicyStep::NoStep),
         }
     }


### PR DESCRIPTION
tss-esapi 7.7.0 vendors bindgen 0.72.1, which resolves the FTBFS caused by Clang 22 breaking changes. Also refactors is_some()+unwrap() patterns to match expressions to satisfy newer clippy lints.